### PR TITLE
Update overview.md

### DIFF
--- a/docs/src/resolvers/ExampleSetup/overview.md
+++ b/docs/src/resolvers/ExampleSetup/overview.md
@@ -56,7 +56,7 @@ Content of the USD file located at `/workspace/shots/shotA/shotA_mapping.usd`
 )
 ```
 
-Content of the USD files located at `/workspace/assets/assetA/assetA.usd` and `/workspace/assets/assetA/assetA_v002.usd`
+Content of the USD file located at `/workspace/assets/assetA/assetA_v002.usd`
 ```python
 #usda 1.0
 def Cube "box" ()


### PR DESCRIPTION
The production example states that /workpace/assets/assetA/assetA.usd  is the same as v001 and the same as v002. 
¨Content of the USD files located at /workspace/assets/assetA/assetA.usd and /workspace/assets/assetA/assetA_v002.usd¨ 
¨Content of the USD file located at /workspace/assets/assetA/assetA.usd and /workspace/assets/assetA/assetA_v001.usd"

The sentence ´You'll see the box being replaced to cylinder.´ makes only sense to me if assetA.usd initially has a box referenced (so is not the same as v002)